### PR TITLE
improv: Fetch purposes when starting, and show in UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "hp-vendor-client"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/hp-vendor#8dc8da39193ff4edbfd7bd104714ec1c764e8262"
+source = "git+https://github.com/pop-os/hp-vendor#161fdcd4ba19e5f36f12abc078aee7a859c46f46"
 dependencies = [
  "once_cell",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "hp-vendor-client"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/hp-vendor#161fdcd4ba19e5f36f12abc078aee7a859c46f46"
+source = "git+https://github.com/pop-os/hp-vendor#b6ed4c0bbe215f5e612b4ea413fb72ba6a0b20f3"
 dependencies = [
  "once_cell",
  "serde",

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:
   just,
   rustc,
   libgtk-3-dev,
+  pkexec,
   pkg-config,
 Standards-Version: 4.3.0
 Homepage: https://github.com/pop-os/analytics-panel

--- a/i18n/en/pop_analytics_panel.ftl
+++ b/i18n/en/pop_analytics_panel.ftl
@@ -11,6 +11,7 @@ data-deleted-header = Data Has Been Deleted
 delete = Delete
 delete-data-description = Data will be permanently erased from HP and can't be downloaded after deletion.
 delete-data-header = Delete Data?
+error-header = Error
 no-data-description = There is no data for this device in HP
 no-data-header = No Data Retained
 no-internet-description = Please check the internet connection and try again.

--- a/src/components/hp/dialog.rs
+++ b/src/components/hp/dialog.rs
@@ -29,6 +29,7 @@ pub enum Variant {
     DataDownloaded,
     Deleted,
     DeleteData,
+    Error(hp_vendor_client::Error),
     NoDataFound,
     NoInternet,
 }
@@ -87,6 +88,15 @@ impl Widget {
         );
     }
 
+    fn error_view(&self, error: &hp_vendor_client::Error) {
+        self.configure_view(
+            &fl!("error-header"),
+            &error.to_string(),
+            &fl!("close"),
+            None,
+        );
+    }
+
     fn no_data_found_view(&self) {
         self.configure_view(
             &fl!("no-data-header"),
@@ -114,6 +124,7 @@ impl Widget {
             match variant {
                 Variant::Deleted => self.data_deleted_view(),
                 Variant::DeleteData => self.delete_data_confirmation_view(),
+                Variant::Error(ref error) => self.error_view(error),
                 Variant::NoDataFound => self.no_data_found_view(),
                 Variant::NoInternet => self.no_internet_view(),
                 Variant::DataDownloaded => self.data_downloaded_view(),

--- a/src/components/hp/summary.rs
+++ b/src/components/hp/summary.rs
@@ -4,13 +4,18 @@ use concat_in_place::strcat;
 use gtk::prelude::*;
 
 pub struct Model {
+    background: relm::Sender<Message>,
     show_toggle: bool,
+    purpose: Option<(String, String, String, String)>,
+    relm: relm::Relm<Widget>,
 }
 
 #[derive(relm_derive::Msg)]
 pub enum Message {
     DisplaySample,
     OpenWebpage(&'static str),
+    PurposeAndOpt(super::PurposeAndOpt),
+    PurposeStatement(String),
     Toggle,
 }
 
@@ -46,10 +51,32 @@ impl relm::Widget for Widget {
             .link3
             .style_context()
             .add_class("analytics-link");
+
+        if self.model.show_toggle {
+            let tx = self.model.background.clone();
+            glib::MainContext::default().spawn_local(async move {
+                if let Ok(purpose_and_opt) = super::purpose_and_opted(false).await {
+                    tx.send(Message::PurposeAndOpt(purpose_and_opt));
+                } else {
+                    // TODO? Shouldn't happen if hp-vendor installed correctly
+                }
+            });
+        }
     }
 
-    fn model(_: &relm::Relm<Self>, show_toggle: bool) -> Model {
-        Model { show_toggle }
+    fn model(relm: &relm::Relm<Self>, show_toggle: bool) -> Model {
+        let stream = relm.stream().clone();
+
+        let (_channel, sender) = relm::Channel::new(move |message| {
+            stream.emit(message);
+        });
+
+        Model {
+            background: sender,
+            show_toggle,
+            purpose: None,
+            relm: relm.clone(),
+        }
     }
 
     fn update(&mut self, message: Message) {
@@ -60,11 +87,33 @@ impl relm::Widget for Widget {
                 crate::misc::xdg_open(url);
             }
 
+            Message::PurposeAndOpt(super::PurposeAndOpt {
+                language,
+                region,
+                purpose,
+                opted,
+            }) => {
+                {
+                    let _lock = self.model.relm.stream().lock();
+                    self.widgets.toggle.set_active(opted);
+                }
+                self.widgets.toggle.set_active(opted);
+                self.widgets.toggle.set_sensitive(true);
+                self.widgets.purpose_statement.set_text(&purpose.statement);
+                self.model.purpose = Some((language, region, purpose.purpose_id, purpose.version));
+            }
+
+            Message::PurposeStatement(statement) => {
+                self.widgets.purpose_statement.set_text(&statement);
+            }
+
             Message::Toggle => {
                 let enable = self.widgets.toggle.is_active();
-                glib::MainContext::default().spawn_local(async move {
-                    super::toggle(enable).await;
-                });
+                if let Some(purpose) = self.model.purpose.clone() {
+                    glib::MainContext::default().spawn_local(async move {
+                        super::toggle(purpose, enable).await;
+                    });
+                }
             }
         }
     }
@@ -122,6 +171,10 @@ impl relm::Widget for Widget {
                 label: &fl!("pop-privacy-policy"),
                 activate_link => (Message::OpenWebpage(""), gtk::Inhibit(false)),
                 margin_bottom: 24,
+            },
+
+            #[name="purpose_statement"]
+            gtk::Label {
             },
         }
     }


### PR DESCRIPTION
The way it is shown is not ideal, but we want to update the design here anyway. So I didn't try to style it especially well.

This fetches purposes from the server when used in Gnome Control Center (falling back to a version hard-coded in hp-vendor), but doesn't attempt fetching in Gnome Initial Setup. This is apparently the desired behavior, though it's not great that it takes some time to communicate with the server for this, before it's possible to show purpose text or send opt in.