### PR TITLE
Show custom error message for not enrolled

### DIFF
--- a/i18n/en/pop_analytics_panel.ftl
+++ b/i18n/en/pop_analytics_panel.ftl
@@ -33,3 +33,7 @@ download-option-downloading = Downloading data archive
 data-downloaded-header = Download Data
 data-downloaded-description = Data has been downloaded
 open-folder = Open Folder
+not-enrolled-description = An error occurred in our system that is preventing this device from being recognized.
+                           Please contact support to resolve this issue.
+open-support-panel = Open Support Panel
+device-id-invalid-description = This device is not recognized by our system. The device IDs do not match the expected format.

--- a/src/components/hp/dialog.rs
+++ b/src/components/hp/dialog.rs
@@ -32,6 +32,8 @@ pub enum Variant {
     Error(hp_vendor_client::Error),
     NoDataFound,
     NoInternet,
+    NotEnrolled,
+    DeviceIdInvalid,
 }
 
 impl Widget {
@@ -115,6 +117,24 @@ impl Widget {
         );
     }
 
+    fn not_enrolled_view(&self) {
+        self.configure_view(
+            &fl!("error-header"),
+            &fl!("not-enrolled-description"),
+            &fl!("close"),
+            Some(&fl!("open-support-panel")),
+        );
+    }
+
+    fn device_id_error_view(&self) {
+        self.configure_view(
+            &fl!("error-header"),
+            &fl!("device-id-invalid-description"),
+            &fl!("close"),
+            None,
+        );
+    }
+
     fn send(&self, message: panel::Message) {
         let _ = self.model.sender.emit(message);
     }
@@ -128,6 +148,8 @@ impl Widget {
                 Variant::NoDataFound => self.no_data_found_view(),
                 Variant::NoInternet => self.no_internet_view(),
                 Variant::DataDownloaded => self.data_downloaded_view(),
+                Variant::NotEnrolled => self.not_enrolled_view(),
+                Variant::DeviceIdInvalid => self.device_id_error_view(),
             }
 
             self.model.variant = Some(variant);
@@ -145,6 +167,7 @@ impl relm::Widget for Widget {
                     Some(Variant::DeleteData) => self.send(panel::Message::Delete),
                     Some(Variant::NoInternet) => self.send(panel::Message::TryAgain),
                     Some(Variant::DataDownloaded) => self.send(panel::Message::OpenDataDir),
+                    Some(Variant::NotEnrolled) => self.send(panel::Message::OpenSupportPanel),
                     _ => (),
                 }
 
@@ -177,6 +200,8 @@ impl relm::Widget for Widget {
             orientation: gtk::Orientation::Vertical,
             spacing: 24,
             margin_top: 8,
+            margin_start: 8,
+            margin_end: 8,
 
             #[name="header"]
             gtk::Label {


### PR DESCRIPTION
This has been discussed since it seems to be an issue in a few cases, and a clearer error message may be helpful.

Testing this may require patching `DeviceOSIds::new` in `hp-vendor` to return something that passes regex checks but isn't enrolled.

![Screenshot from 2022-06-20 13-51-10](https://user-images.githubusercontent.com/2263150/174676159-8084ed93-7052-4a9c-a992-70aa2796b57a.png)

The only real question here is the best message to show. Or other details of the dialog.